### PR TITLE
add nix devshell

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ sudo apt install libwebkit2gtk-4.1-dev libxdo-dev
 sudo dnf install gtk3-devel webkit2gtk4.1-devel xdotool
 ```
 
+#### Nix/NixOS
+
+For development:
+```bash
+nix develop
+```
+
+To build and run:
+```bash
+# with a local checkout
+nix run .
+
+# without a local checkout
+nix run github:adriankumpf/tesla_auth
+```
+
 ## Development
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "tesla_auth";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+  outputs =
+    {
+      nixpkgs,
+      ...
+    }:
+    let
+      cargoToml = fromTOML (builtins.readFile ./Cargo.toml);
+      forAllSystems = with nixpkgs; (lib.genAttrs lib.systems.flakeExposed);
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixfmt);
+      deps = pkgs: with pkgs; [
+        glib
+        pango
+        atk
+        webkitgtk_4_1
+        libsoup_3
+        xdotool
+      ];
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = cargoToml.package.name;
+            version = cargoToml.package.version;
+
+            src = ./.;
+
+            cargoLock.lockFile = ./Cargo.lock;
+
+            nativeBuildInputs = with pkgs; [
+              makeWrapper
+              pkg-config
+            ];
+
+            buildInputs = deps pkgs;
+
+            postInstall = ''
+              wrapProgram $out/bin/tesla_auth \
+                --set GIO_MODULE_DIR "${pkgs.glib-networking}/lib/gio/modules"
+            '';
+
+            meta = {
+              description = cargoToml.package.description;
+              homepage = "https://github.com/adriankumpf/tesla_auth";
+              license = pkgs.lib.licenses.mit;
+              mainProgram = "tesla_auth";
+            };
+          };
+        }
+      );
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            name = "tesla_auth";
+
+            buildInputs = with pkgs; [
+              rustc
+              rustfmt
+              cargo
+              rust-analyzer
+              clippy
+              cargo-watch
+              pkg-config
+              cargo-audit
+              cargo-outdated
+              lldb
+            ] ++ (deps pkgs);
+
+            RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+            GIO_MODULE_DIR = "${pkgs.glib-networking}/lib/gio/modules";
+          };
+        }
+      );
+      inherit formatter;
+    };
+}


### PR DESCRIPTION
From any machine with nix, you can work on the project with:

```bash
nix develop
```
to enter a shell with everything you need to make `cargo build` and friends work.

Users can run:
```bash
# with a project checkout
nix run .

# or, without one:
nix run github:kylesferrazza/tesla_auth/nix-flake
# and, after you merge:
nix run github:adriankumpf/tesla_auth
```

to run tesla_auth without any additional steps.