### PR TITLE
feat: add Nix flake support for NixOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ sudo apt install libwebkit2gtk-4.1-dev libxdo-dev
 sudo dnf install gtk3-devel webkit2gtk4.1-devel xdotool
 ```
 
+#### NixOS
+
+A [`flake.nix`](flake.nix) is included in the repository, providing a reproducible
+build and development environment. No manual dependency installation is needed.
+
+```bash
+# Build the release binary → result/bin/tesla_auth
+nix build
+
+# Run directly (the binary is wrapped with all required env vars)
+./result/bin/tesla_auth
+
+# Or compile and run in one step
+nix run
+```
+
+For development:
+
+```bash
+# Enter a dev shell with Rust toolchain and all dependencies
+nix develop
+
+# Inside the dev shell:
+cargo build
+cargo run
+```
+
+The flake uses `nixos-unstable` and pins all dependencies (including `webkitgtk_4_1`,
+`glib-networking` for TLS support, and `nss` for certificates) via `flake.lock`.
+
 ## Development
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+{
+  description = "Tesla Auth — Tesla API token generator";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        # Runtime dependencies for WebKitGTK-based WebView
+        buildInputs = [
+          pkgs.webkitgtk_4_1
+          pkgs.xdotool
+          pkgs.gtk3
+          pkgs.cairo
+          pkgs.pango
+          pkgs.gdk-pixbuf
+          pkgs.glib
+          pkgs.libsoup_3
+          pkgs.openssl
+          pkgs.glib-networking # TLS backend for HTTPS in WebKitGTK
+          pkgs.nss # Certificates and crypto for WebKit
+        ];
+
+        nativeBuildInputs = [
+          pkgs.pkg-config
+          pkgs.wrapGAppsHook3 # Wraps binary with GIO/NSS env vars at install time
+        ];
+      in
+      {
+        # `nix build` → binary at result/bin/tesla_auth
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "tesla_auth";
+          version = "0.13.0";
+
+          src = ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          inherit nativeBuildInputs buildInputs;
+
+          # Disable static_vcruntime build script (MSVC-only, irrelevant on Linux)
+          STATIC_VCRUNTIME_NO_BUILD = "1";
+
+          doCheck = false; # Tests require a graphical display (WebView)
+        };
+
+        # `nix develop` → development shell with Rust toolchain and all dependencies
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            rustc
+            cargo
+            clippy
+            rustfmt
+          ];
+
+          inherit buildInputs;
+
+          RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+
+          # TLS: glib-networking provides the GIO module for HTTPS in WebKitGTK
+          GIO_EXTRA_MODULES = "${pkgs.glib-networking}/lib/gio/modules";
+
+          # pkg-config must be able to locate the libraries
+          PKG_CONFIG_PATH = with pkgs; lib.makeSearchPath "lib/pkgconfig" [
+            webkitgtk_4_1
+            gtk3
+            libsoup_3
+          ];
+        };
+      });
+}


### PR DESCRIPTION
## Summary

Add a `flake.nix` to support reproducible builds and development on NixOS, where the native dependencies (WebKitGTK, GTK3, libsoup3, etc.) cannot be installed via `apt`/`pacman`/`dnf`.

### What the flake provides

- **`nix build`** → produces a release binary at `result/bin/tesla_auth`, wrapped with `wrapGAppsHook3` so it runs standalone with all required environment variables (`GIO_EXTRA_MODULES` for TLS, `NSS_DATABASE_DIR` for certificates)
- **`nix develop`** → dev shell with the Rust toolchain (`rustc`, `cargo`, `clippy`, `rustfmt`) and all native dependencies (`webkitgtk_4_1`, `gtk3`, `libsoup_3`, `glib-networking`, `nss`, `xdotool`)
- **`nix run`** → build and run in one step

### Key details

- Uses `nixos-unstable` + `flake-utils` for multi-platform support
- `glib-networking` is included to provide the GIO TLS module (`libgiognutls.so`) that WebKitGTK needs for HTTPS — without it, WebKitGTK fails with *"TLS support is not available"*
- `nss` provides certificate/crypto support for WebKit
- `STATIC_VCRUNTIME_NO_BUILD=1` disables the MSVC-only `static_vcruntime` build script on Linux
- `doCheck = false` because tests require a graphical display (WebView)
- `flake.lock` pins all dependencies for reproducibility

### Files changed

| File | Change |
|------|--------|
| `flake.nix` | New — flake definition with `packages.default` and `devShells.default` |
| `flake.lock` | New — pinned dependency versions |
| `README.md` | Add NixOS section alongside existing Arch/Debian/Fedora instructions |
| `.gitignore` | Add `result` and `result-*` (Nix build outputs) |

### Verification

Tested on NixOS 26.05 with Nix 2.34.8:

- ✅ `nix build` produces a working binary
- ✅ `nix develop` provides all tools and dependencies
- ✅ Binary loads `auth.tesla.com` via HTTPS (TLS works)
- ✅ hCaptcha renders correctly in the WebView