### PR TITLE
Clean up and simplify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,29 +90,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,8 +187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -266,15 +241,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -646,12 +612,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -1318,36 +1278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys 0.4.1",
- "log",
- "simd_cesu8",
- "thiserror 2.0.20",
- "walkdir",
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,16 +1303,6 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
-dependencies = [
- "getrandom 0.4.3",
- "libc",
 ]
 
 [[package]]
@@ -1620,7 +1540,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "rand 0.8.7",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -1828,12 +1748,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -2091,7 +2005,6 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -2260,43 +2173,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,25 +2207,12 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
- "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -2363,39 +2226,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni 0.22.4",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2423,42 +2258,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "selectors"
@@ -2591,22 +2394,6 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
-
-[[package]]
-name = "simd_cesu8"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_logger"
@@ -2795,7 +2582,7 @@ dependencies = [
  "dpi",
  "gdkwayland-sys",
  "gtk",
- "jni 0.21.1",
+ "jni",
  "libc",
  "log",
  "ndk",
@@ -2852,7 +2639,6 @@ dependencies = [
  "log",
  "muda",
  "oauth2",
- "reqwest 0.13.4",
  "serde_json",
  "simple_logger",
  "static_vcruntime",
@@ -3336,15 +3122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3767,7 +3544,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni 0.21.1",
+ "jni",
  "libc",
  "ndk",
  "objc2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,7 +2639,6 @@ dependencies = [
  "log",
  "muda",
  "oauth2",
- "serde_json",
  "simple_logger",
  "static_vcruntime",
  "tao",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,18 +10,18 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "argh"
@@ -42,7 +42,7 @@ dependencies = [
  "argh_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -85,15 +85,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -101,14 +101,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -140,9 +141,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -167,15 +168,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cairo-rs"
@@ -183,7 +184,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -204,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -238,15 +239,26 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -277,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "time",
  "version_check",
@@ -307,7 +319,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -320,7 +332,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "libc",
 ]
@@ -330,6 +342,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -345,18 +366,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -370,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
@@ -383,12 +404,12 @@ dependencies = [
 
 [[package]]
 name = "cssparser-macros"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -396,9 +417,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_more"
@@ -418,7 +436,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -458,7 +476,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -466,13 +484,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -495,14 +513,14 @@ checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "dom_query"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
+checksum = "fac5fca71e65e94cc718a6e2af65d6e0f9c6027751c2aa562fbb5087fda639bc"
 dependencies = [
  "bit-set",
  "cssparser",
@@ -548,9 +566,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -573,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
 
 [[package]]
 name = "flate2"
@@ -605,13 +623,13 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-macros"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -637,9 +655,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -647,15 +665,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -664,38 +682,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -831,15 +849,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasip2",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -881,7 +899,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -909,7 +927,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -982,14 +1000,14 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1005,9 +1023,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "html5ever"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
@@ -1015,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1025,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1035,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1054,9 +1072,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1250,19 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itoa"
@@ -1321,7 +1329,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link 0.2.1",
 ]
@@ -1336,7 +1344,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1364,28 +1372,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1395,22 +1402,22 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -1451,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1463,9 +1470,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
@@ -1474,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -1499,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1510,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.19.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -1525,7 +1532,7 @@ dependencies = [
  "objc2-foundation",
  "once_cell",
  "png",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -1535,7 +1542,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -1543,6 +1550,12 @@ dependencies = [
  "raw-window-handle",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
@@ -1561,9 +1574,9 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1593,7 +1606,7 @@ dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1606,7 +1619,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http",
- "rand 0.8.6",
+ "rand 0.8.7",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -1632,7 +1645,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -1644,7 +1657,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -1665,7 +1678,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -1676,7 +1689,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -1709,7 +1722,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -1736,7 +1749,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
+ "block2",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1747,7 +1761,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1758,7 +1772,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -1770,7 +1784,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -1801,7 +1815,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -1922,7 +1936,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1952,7 +1966,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2015,7 +2029,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -2044,18 +2058,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2065,7 +2079,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -2073,21 +2087,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2095,52 +2110,53 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2154,16 +2170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2174,11 +2180,17 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2193,7 +2205,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -2204,7 +2216,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2249,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -2300,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2315,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2330,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2342,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2391,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2431,7 +2443,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2450,11 +2462,11 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cssparser",
  "derive_more",
  "log",
@@ -2475,9 +2487,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2485,29 +2497,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2564,27 +2576,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -2608,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2620,15 +2632,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2714,9 +2726,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2740,7 +2763,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2758,11 +2781,11 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf65722394c2ac443e80120064987f8914ee1d4e4e36e63cdf10f2990f01159"
+checksum = "e9fa4618f999c4249db1681cba0a19b890718f274de7fa93c445d46bd3a8a999"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "core-foundation",
  "core-graphics",
@@ -2776,6 +2799,7 @@ dependencies = [
  "libc",
  "log",
  "ndk",
+ "ndk-context",
  "ndk-sys",
  "objc2",
  "objc2-app-kit",
@@ -2795,13 +2819,13 @@ dependencies = [
 
 [[package]]
 name = "tao-macros"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+checksum = "5f7eeb6d99155545da6150a1795945f16ac9c178deb2a5f2e74d776107bd5849"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2812,12 +2836,11 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tendril"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
  "new_debug_unreachable",
- "utf-8",
 ]
 
 [[package]]
@@ -2829,7 +2852,7 @@ dependencies = [
  "log",
  "muda",
  "oauth2",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde_json",
  "simple_logger",
  "static_vcruntime",
@@ -2848,11 +2871,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -2863,28 +2886,27 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2894,15 +2916,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2920,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2935,9 +2957,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3013,23 +3035,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3049,20 +3071,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3104,9 +3126,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -3116,9 +3138,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "untrusted"
@@ -3138,12 +3160,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -3189,19 +3205,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3212,9 +3219,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3222,9 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3232,31 +3239,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3274,9 +3281,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -3330,18 +3337,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3368,7 +3375,7 @@ checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3377,7 +3384,7 @@ version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "windows",
  "windows-core 0.61.2",
 ]
@@ -3480,7 +3487,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3491,7 +3498,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3572,15 +3579,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3612,28 +3610,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3667,12 +3648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3683,12 +3658,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3703,22 +3672,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3733,12 +3690,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3749,12 +3700,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3769,12 +3714,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3787,12 +3726,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3803,18 +3736,12 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -3824,9 +3751,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3013fd6116aac351dd2e18f349b28b2cfef3a5ff3253a9d0ce2d7193bb1b4429"
+checksum = "1730ab21a962e7ff44df17d20804572beee66d998afc7fcbc3f846a3a12dbda7"
 dependencies = [
  "base64",
  "block2",
@@ -3855,7 +3782,7 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",
@@ -3889,9 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3906,35 +3833,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -3947,15 +3874,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -3987,11 +3914,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,21 +13,21 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.102"
+anyhow = "1.0.104"
 argh = "0.1.19"
-log = "0.4.29"
-muda = "0.19.1"
+log = "0.4.33"
+muda = "0.19.3"
 oauth2 = { version = "5.0.0", features = ["reqwest-blocking" ] }
-reqwest = { version = "0.13.3", default-features = false, features = [
+reqwest = { version = "0.13.4", default-features = false, features = [
   "json",
   "rustls",
 ] }
-serde_json = "1.0.149"
+serde_json = "1.0.150"
 simple_logger = { version = "5.2.0", default-features = false, features = [
   "stderr",
 ] }
-tao = { version = "0.35", default-features = false, features = ["rwh_06"] }
-wry = { version = "0.55.0", features = ["devtools"] }
+tao = { version = "0.36", default-features = false, features = ["rwh_06"] }
+wry = { version = "0.56.0", features = ["devtools"] }
 
 [build-dependencies]
 static_vcruntime = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,7 @@ anyhow = "1.0.104"
 argh = "0.1.19"
 log = "0.4.33"
 muda = "0.19.3"
-oauth2 = { version = "5.0.0", features = ["reqwest-blocking" ] }
-reqwest = { version = "0.13.4", default-features = false, features = [
-  "json",
-  "rustls",
-] }
+oauth2 = { version = "5.0.0", features = ["reqwest-blocking"] }
 serde_json = "1.0.150"
 simple_logger = { version = "5.2.0", default-features = false, features = [
   "stderr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ argh = "0.1.19"
 log = "0.4.33"
 muda = "0.19.3"
 oauth2 = { version = "5.0.0", features = ["reqwest-blocking"] }
-serde_json = "1.0.150"
 simple_logger = { version = "5.2.0", default-features = false, features = [
   "stderr",
 ] }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
 
@@ -5,7 +6,7 @@ use anyhow::anyhow;
 
 use oauth2::basic::BasicClient;
 use oauth2::reqwest;
-use oauth2::url::{Host, Url};
+use oauth2::url::Url;
 use oauth2::{
     AccessToken, AuthType, AuthUrl, AuthorizationCode, ClientId, CsrfToken, ExtraTokenFields,
     PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken, Scope, StandardTokenResponse,
@@ -23,9 +24,16 @@ const AUTH_URL: &str = "https://auth.tesla.com/oauth2/v3/authorize";
 const TOKEN_URL: &str = "https://auth.tesla.com/oauth2/v3/token";
 const TOKEN_URL_CN: &str = "https://auth.tesla.cn/oauth2/v3/token";
 const REDIRECT_URL: &str = "tesla://auth/callback";
+const SCOPES: &[&str] = &["openid", "email", "offline_access"];
 
 pub fn is_redirect_url(url: &Url) -> bool {
     url.as_str().starts_with(REDIRECT_URL)
+}
+
+#[derive(Debug)]
+pub enum Outcome {
+    Authorized(Tokens),
+    Canceled,
 }
 
 #[derive(Debug, Clone)]
@@ -60,87 +68,95 @@ impl fmt::Display for Tokens {
 }
 
 pub struct Client {
-    auth_url: Url,
+    authorize_url: Url,
     oauth_client: ConfiguredClient,
-    oauth_client_cn: ConfiguredClient,
+    token_url_cn: TokenUrl,
     pkce_verifier: PkceCodeVerifier,
     csrf_token: CsrfToken,
 }
 
 impl Client {
     pub fn new() -> Client {
-        let auth_url =
-            AuthUrl::new(AUTH_URL.to_string()).expect("Invalid authorization endpoint URL");
-        let redirect_url =
-            RedirectUrl::new(REDIRECT_URL.to_string()).expect("Invalid redirect URL");
-
-        let token_url = TokenUrl::new(TOKEN_URL.to_string()).expect("Invalid token endpoint URL");
-
-        let token_url_cn =
-            TokenUrl::new(TOKEN_URL_CN.to_string()).expect("Invalid token endpoint URL");
-
         let oauth_client = BasicClient::new(ClientId::new(CLIENT_ID.to_string()))
             .set_auth_type(AuthType::RequestBody)
-            .set_redirect_uri(redirect_url.clone())
-            .set_auth_uri(auth_url.clone())
-            .set_token_uri(token_url.clone());
+            .set_redirect_uri(RedirectUrl::new(REDIRECT_URL.to_string()).expect("valid URL"))
+            .set_auth_uri(AuthUrl::new(AUTH_URL.to_string()).expect("valid URL"))
+            .set_token_uri(TokenUrl::new(TOKEN_URL.to_string()).expect("valid URL"));
 
-        let oauth_client_cn = BasicClient::new(ClientId::new(CLIENT_ID.to_string()))
-            .set_auth_type(AuthType::RequestBody)
-            .set_redirect_uri(redirect_url)
-            .set_auth_uri(auth_url)
-            .set_token_uri(token_url_cn);
+        let token_url_cn = TokenUrl::new(TOKEN_URL_CN.to_string()).expect("valid URL");
 
         let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
 
-        let (auth_url, csrf_token) = oauth_client
+        let (authorize_url, csrf_token) = oauth_client
             .authorize_url(CsrfToken::new_random)
-            .add_scope(Scope::new("openid".to_string()))
-            .add_scope(Scope::new("email".to_string()))
-            .add_scope(Scope::new("offline_access".to_string()))
+            .add_scopes(SCOPES.iter().map(|scope| Scope::new(scope.to_string())))
             .set_pkce_challenge(pkce_challenge)
             .url();
 
         Client {
+            authorize_url,
             oauth_client,
-            oauth_client_cn,
-            auth_url,
+            token_url_cn,
             pkce_verifier,
             csrf_token,
         }
     }
 
-    pub fn authorize_url(&self) -> Url {
-        self.auth_url.clone()
+    pub fn authorize_url(&self) -> &Url {
+        &self.authorize_url
     }
 
-    pub fn retrieve_tokens(self, code: &str, state: &str, issuer: &Url) -> anyhow::Result<Tokens> {
+    /// Exchanges the authorization code carried by the callback URL for a set
+    /// of tokens.
+    ///
+    /// Consumes the client: both the PKCE verifier and the authorization code
+    /// are single-use.
+    pub fn authenticate(self, callback_url: &Url) -> anyhow::Result<Outcome> {
+        let query: HashMap<_, _> = callback_url.query_pairs().collect();
+
+        if query
+            .get("error")
+            .is_some_and(|error| error == "login_cancelled")
+        {
+            return Ok(Outcome::Canceled);
+        }
+
+        let (Some(code), Some(state), Some(issuer)) =
+            (query.get("code"), query.get("state"), query.get("issuer"))
+        else {
+            return Err(anyhow!(
+                "Callback URL is missing required query parameters (code, state or issuer)"
+            ));
+        };
+
         if state != self.csrf_token.secret() {
             return Err(anyhow!("CSRF state does not match!"));
         }
 
-        let client = match issuer.host() {
-            Some(Host::Domain("auth.tesla.cn")) => self.oauth_client_cn,
-            _global => self.oauth_client,
+        let issuer = Url::parse(issuer).map_err(|e| anyhow!("Invalid issuer URL: {e}"))?;
+
+        // Accounts registered in China are issued tokens by a separate endpoint.
+        let oauth_client = if issuer.host() == self.token_url_cn.url().host() {
+            self.oauth_client.set_token_uri(self.token_url_cn)
+        } else {
+            self.oauth_client
         };
 
         let http_client = reqwest::blocking::ClientBuilder::new()
             .redirect(reqwest::redirect::Policy::none())
             .build()?;
 
-        let sso_token: SsoToken = client
+        let sso_token: SsoToken = oauth_client
             .exchange_code(AuthorizationCode::new(code.to_string()))
             .set_pkce_verifier(self.pkce_verifier)
             .request(&http_client)?
             .try_into()?;
 
-        let tokens = Tokens {
+        Ok(Outcome::Authorized(Tokens {
             access: sso_token.access_token,
             refresh: sso_token.refresh_token,
             expires_in: sso_token.expires_in.into(),
-        };
-
-        Ok(tokens)
+        }))
     }
 }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -26,6 +26,10 @@ const TOKEN_URL_CN: &str = "https://auth.tesla.cn/oauth2/v3/token";
 const REDIRECT_URL: &str = "tesla://auth/callback";
 const SCOPES: &[&str] = &["openid", "email", "offline_access"];
 
+/// Without a timeout an unresponsive endpoint would leave the window stuck
+/// mid-flow forever.
+const EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub fn is_redirect_url(url: &Url) -> bool {
     url.as_str().starts_with(REDIRECT_URL)
 }
@@ -144,6 +148,7 @@ impl Client {
 
         let http_client = reqwest::blocking::ClientBuilder::new()
             .redirect(reqwest::redirect::Policy::none())
+            .timeout(EXCHANGE_TIMEOUT)
             .build()?;
 
         let sso_token: SsoToken = oauth_client

--- a/src/htime.rs
+++ b/src/htime.rs
@@ -1,7 +1,11 @@
 use std::fmt;
 use std::time;
 
-/// A wrapper type that allows to display a Duration
+const MINUTE: u64 = 60;
+const HOUR: u64 = 60 * MINUTE;
+const DAY: u64 = 24 * HOUR;
+
+/// Wraps a [`time::Duration`] to display it as e.g. `1 day 23 hours 59 minutes`.
 #[derive(Debug, Clone)]
 pub struct Duration(time::Duration);
 
@@ -13,43 +17,30 @@ impl From<time::Duration> for Duration {
 
 impl fmt::Display for Duration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        pretty_print(f, &self.0)
-    }
-}
+        let mut remaining = self.0.as_secs();
 
-const MINUTE: u64 = 60;
-const HOUR: u64 = 60 * MINUTE;
-const DAY: u64 = 24 * HOUR;
-
-fn pretty_print(f: &mut fmt::Formatter<'_>, d: &time::Duration) -> fmt::Result {
-    let mut d = d.as_secs();
-    let mut first = true;
-
-    for (secs, suffix) in [(DAY, "day"), (HOUR, "hour"), (MINUTE, "minute")] {
-        if d < secs {
-            continue;
+        if remaining < MINUTE {
+            return f.write_str("less than a minute");
         }
 
-        let units = d / secs;
+        let mut separator = "";
 
-        if !first {
-            f.write_str(" ")?;
+        for (secs, unit) in [(DAY, "day"), (HOUR, "hour"), (MINUTE, "minute")] {
+            let units = remaining / secs;
+            remaining %= secs;
+
+            if units == 0 {
+                continue;
+            }
+
+            let plural = if units == 1 { "" } else { "s" };
+
+            write!(f, "{separator}{units} {unit}{plural}")?;
+            separator = " ";
         }
-        first = false;
 
-        write!(f, "{units} {suffix}")?;
-        if units != 1 {
-            f.write_str("s")?;
-        }
-
-        d %= secs;
+        Ok(())
     }
-
-    if first {
-        f.write_str("less than a minute")?;
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -57,7 +48,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_pretty_print() {
+    fn formats_durations_in_words() {
         let pp = |secs| Duration::from(time::Duration::from_secs(secs)).to_string();
 
         assert_eq!(pp(0), "less than a minute");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::sync::mpsc::{Sender, channel};
 use std::thread;
 
 use log::LevelFilter;
-use oauth2::url::Url;
+use oauth2::url::{Position, Url};
 use simple_logger::SimpleLogger;
 
 use muda::{Menu, PredefinedMenuItem, Submenu};
@@ -73,7 +73,7 @@ fn main() -> anyhow::Result<()> {
 
     let tx = spawn_token_exchange(auth_client, event_proxy);
 
-    log::debug!("Opening {auth_url} ...");
+    log::debug!("Opening {} ...", &auth_url[..Position::AfterPath]);
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
@@ -244,7 +244,8 @@ fn handle_navigation(event_proxy: &EventLoopProxy<UserEvent>, uri: String) -> bo
     };
 
     if !auth::is_redirect_url(&url) {
-        log::debug!("Navigating to {url} ...");
+        // Everything past the path is redacted: it carries the CSRF state.
+        log::debug!("Navigating to {} ...", &url[..Position::AfterPath]);
         return true;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,25 +19,12 @@ use wry::WebViewBuilder;
 
 mod auth;
 mod htime;
-
-const INITIALIZATION_SCRIPT: &str = r#"
-window.addEventListener('DOMContentLoaded', (event) => {
-    const url = window.location.toString();
-
-    if (url.startsWith("tesla://auth/callback")) {
-       const loadingText = document.querySelector(
-           '[class*="validated-success-message"], h1.h1'
-       );
-       if (loadingText) {
-           loadingText.textContent = "Generating Tokens ...";
-       }
-    }
-});
-"#;
+mod view;
 
 #[derive(Debug)]
 enum UserEvent {
-    Navigation(Url),
+    /// The SSO flow reached the callback URL; the code exchange starts now.
+    Redirect(Url),
     Tokens(auth::Tokens),
     Failure(anyhow::Error),
     LoginCanceled,
@@ -127,13 +114,22 @@ fn main() -> anyhow::Result<()> {
     let proxy = event_proxy.clone();
 
     let builder = WebViewBuilder::new()
-        .with_initialization_script(INITIALIZATION_SCRIPT)
         .with_navigation_handler(move |uri: String| {
-            let Ok(uri) = Url::parse(&uri) else {
+            let Ok(url) = Url::parse(&uri) else {
                 log::warn!("Ignoring malformed navigation URL: {uri}");
                 return false;
             };
-            proxy.send_event(UserEvent::Navigation(uri)).is_ok()
+
+            if !auth::is_redirect_url(&url) {
+                log::debug!("Navigating to {url} ...");
+                return true;
+            }
+
+            // Nothing on the system handles the callback scheme, so following
+            // it would at best fail and at worst hand the authorization code
+            // to whichever application claims it.
+            let _ = proxy.send_event(UserEvent::Redirect(url));
+            false
         })
         .with_clipboard(true)
         .with_url(auth_url.as_str())
@@ -153,44 +149,50 @@ fn main() -> anyhow::Result<()> {
         webview.clear_all_browsing_data()?;
     }
 
-    let tx = url_handler(auth_client, event_proxy);
+    let tx = spawn_token_exchange(auth_client, event_proxy);
 
     log::debug!("Opening {auth_url} ...");
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
-        match event {
+        let page = match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => *control_flow = ControlFlow::Exit,
+            } => {
+                *control_flow = ControlFlow::Exit;
+                return;
+            }
 
-            Event::UserEvent(UserEvent::Navigation(url)) if url.as_str() != "about:blank" => {
-                log::debug!("URL changed: {url}");
-                let _ = tx.send(url);
+            Event::UserEvent(UserEvent::Redirect(url)) => {
+                if let Err(e) = tx.send(url) {
+                    log::error!("Token exchange is no longer running: {e}");
+                }
+                view::progress()
+            }
+
+            Event::UserEvent(UserEvent::Tokens(tokens)) => {
+                println!("{tokens}");
+                view::tokens(&tokens)
             }
 
             Event::UserEvent(UserEvent::Failure(error)) => {
                 log::error!("{error}");
-                if let Err(e) = webview.evaluate_script(&render_error_view(error)) {
-                    log::error!("Failed to render error view: {e}");
-                }
-            }
-
-            Event::UserEvent(UserEvent::Tokens(token)) => {
-                println!("{token}");
-                if let Err(e) = webview.evaluate_script(&render_tokens_view(token)) {
-                    log::error!("Failed to render tokens view: {e}");
-                }
+                view::error(&error)
             }
 
             Event::UserEvent(UserEvent::LoginCanceled) => {
                 log::warn!("Login canceled");
                 *control_flow = ControlFlow::Exit;
+                return;
             }
 
-            _ => (),
+            _ => return,
+        };
+
+        if let Err(e) = webview.load_html(&page) {
+            log::error!("Failed to render page: {e}");
         }
     });
 }
@@ -213,16 +215,17 @@ fn init_logger(debug: bool) -> anyhow::Result<()> {
 
 /// Exchanges the authorization code on a background thread; the request blocks
 /// and would otherwise freeze the event loop.
-fn url_handler(client: auth::Client, event_proxy: EventLoopProxy<UserEvent>) -> Sender<Url> {
+fn spawn_token_exchange(
+    client: auth::Client,
+    event_proxy: EventLoopProxy<UserEvent>,
+) -> Sender<Url> {
     let (tx, rx) = channel();
 
     thread::spawn(move || {
         // A single callback is all we get: `authenticate` consumes the client.
-        let Some(url) = rx.into_iter().find(auth::is_redirect_url) else {
-            return;
-        };
+        let Ok(callback_url) = rx.recv() else { return };
 
-        let event = match client.authenticate(&url) {
+        let event = match client.authenticate(&callback_url) {
             Ok(auth::Outcome::Authorized(tokens)) => UserEvent::Tokens(tokens),
             Ok(auth::Outcome::Canceled) => UserEvent::LoginCanceled,
             Err(error) => UserEvent::Failure(error),
@@ -232,92 +235,4 @@ fn url_handler(client: auth::Client, event_proxy: EventLoopProxy<UserEvent>) -> 
     });
 
     tx
-}
-
-// Encode a string as a JSON string literal for safe JS interpolation.
-#[expect(clippy::unwrap_used)] // serde_json string serialization is infallible
-fn js_string(s: &str) -> String {
-    serde_json::to_string(s).unwrap()
-}
-
-fn render_error_view(error: anyhow::Error) -> String {
-    let msg = js_string(&error.to_string());
-    format!(
-        r#"(function() {{
-            var mount = document.getElementById("tesla-auth-result");
-            if (!mount) {{
-                mount = document.createElement("div");
-                mount.id = "tesla-auth-result";
-                mount.style.cssText = "position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;padding:24px;background:rgba(255,255,255,0.98);overflow:auto";
-                document.body.appendChild(mount);
-            }}
-
-            mount.replaceChildren();
-
-            var card = document.createElement("div");
-            card.style.cssText = "width:min(720px,100%);display:flex;flex-direction:column;gap:12px;padding:28px;border-radius:16px;background:#fff;box-shadow:0 16px 48px rgba(0,0,0,0.12);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif";
-
-            var h4 = document.createElement("h4");
-            h4.style.cssText = "margin:0;text-align:center;font-size:28px;line-height:1.2";
-            h4.textContent = "An error occurred. Please try again ...";
-            var p = document.createElement("p");
-            p.style.cssText = "margin:0;text-align:center;color:#b91c1c";
-            p.textContent = {msg};
-
-            card.append(h4, p);
-            mount.appendChild(card);
-        }})()"#
-    )
-}
-
-fn render_tokens_view(tokens: auth::Tokens) -> String {
-    let access = js_string(tokens.access.secret());
-    let refresh = js_string(tokens.refresh.secret());
-    let expires = js_string(&tokens.expires_in.to_string());
-    format!(
-        r#"(function() {{
-            var mount = document.getElementById("tesla-auth-result");
-            if (!mount) {{
-                mount = document.createElement("div");
-                mount.id = "tesla-auth-result";
-                mount.style.cssText = "position:fixed;inset:0;z-index:2147483647;display:flex;align-items:center;justify-content:center;padding:24px;background:rgba(255,255,255,0.98);overflow:auto";
-                document.body.appendChild(mount);
-            }}
-
-            mount.replaceChildren();
-
-            var card = document.createElement("div");
-            card.style.cssText = "width:min(900px,100%);display:flex;flex-direction:column;gap:16px;padding:28px;border-radius:16px;background:#fff;box-shadow:0 16px 48px rgba(0,0,0,0.12);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif";
-
-            function addToken(label, value) {{
-                var h4 = document.createElement("h4");
-                h4.style.cssText = "margin:0;text-align:center;font-size:24px;line-height:1.2";
-                h4.textContent = label;
-                card.appendChild(h4);
-                var ta = document.createElement("textarea");
-                ta.readOnly = true;
-                ta.cols = 100;
-                ta.rows = 12;
-                ta.style.cssText = "width:100%;resize:vertical;padding:12px;font:13px/1.4 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;border:1px solid #d1d5db;border-radius:12px;box-sizing:border-box";
-                ta.value = value;
-                ta.addEventListener("click", function() {{ this.setSelectionRange(0, this.value.length); }});
-                card.appendChild(ta);
-            }}
-
-            var title = document.createElement("h3");
-            title.style.cssText = "margin:0;text-align:center;font-size:30px;line-height:1.2";
-            title.textContent = "Tesla API Tokens";
-            card.appendChild(title);
-
-            addToken("Access Token", {access});
-            addToken("Refresh Token", {refresh});
-
-            var small = document.createElement("small");
-            small.style.cssText = "display:block;margin-top:4px;text-align:center;color:seagreen;font-size:14px";
-            small.textContent = "Valid for " + {expires};
-            card.appendChild(small);
-
-            mount.appendChild(card);
-        }})()"#
-    )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,18 +136,14 @@ fn init_logger(debug: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg_attr(
-    target_os = "macos",
-    expect(unused_variables, reason = "the menu bar belongs to the application")
-)]
 fn build_menu_bar(window: &Window) -> anyhow::Result<Menu> {
     let menu_bar = Menu::new();
 
     #[cfg(target_os = "macos")]
-    {
-        let app_menu = Submenu::new("App", true);
-        menu_bar.append(&app_menu)?;
-        app_menu.append_items(&[
+    let app_menu = Submenu::with_items(
+        "App",
+        true,
+        &[
             &PredefinedMenuItem::about(None, None),
             &PredefinedMenuItem::separator(),
             &PredefinedMenuItem::hide(None),
@@ -155,37 +151,36 @@ fn build_menu_bar(window: &Window) -> anyhow::Result<Menu> {
             &PredefinedMenuItem::show_all(None),
             &PredefinedMenuItem::separator(),
             &PredefinedMenuItem::quit(None),
-        ])?;
-    }
+        ],
+    )?;
 
-    let edit_menu = Submenu::new("&Edit", true);
-    edit_menu.append_items(&[
-        #[cfg(target_os = "macos")]
-        &PredefinedMenuItem::undo(None),
-        #[cfg(target_os = "macos")]
-        &PredefinedMenuItem::redo(None),
-        &PredefinedMenuItem::separator(),
-        &PredefinedMenuItem::cut(None),
-        &PredefinedMenuItem::copy(None),
-        &PredefinedMenuItem::paste(None),
-        &PredefinedMenuItem::select_all(None),
-    ])?;
+    let edit_menu = Submenu::with_items(
+        "&Edit",
+        true,
+        &[
+            #[cfg(target_os = "macos")]
+            &PredefinedMenuItem::undo(None),
+            #[cfg(target_os = "macos")]
+            &PredefinedMenuItem::redo(None),
+            &PredefinedMenuItem::separator(),
+            &PredefinedMenuItem::cut(None),
+            &PredefinedMenuItem::copy(None),
+            &PredefinedMenuItem::paste(None),
+            &PredefinedMenuItem::select_all(None),
+        ],
+    )?;
 
+    // The predicates mirror muda's platform support: `fullscreen` exists on
+    // macOS only, `minimize` everywhere but Linux.
     #[cfg(target_os = "macos")]
-    let view_menu = {
-        let view_menu = Submenu::new("&View", true);
-        view_menu.append_items(&[&PredefinedMenuItem::fullscreen(None)])?;
-        view_menu
-    };
+    let view_menu = Submenu::with_items("&View", true, &[&PredefinedMenuItem::fullscreen(None)])?;
 
     #[cfg(not(target_os = "linux"))]
-    let window_menu = {
-        let window_menu = Submenu::new("&Window", true);
-        window_menu.append_items(&[&PredefinedMenuItem::minimize(None)])?;
-        window_menu
-    };
+    let window_menu = Submenu::with_items("&Window", true, &[&PredefinedMenuItem::minimize(None)])?;
 
     menu_bar.append_items(&[
+        #[cfg(target_os = "macos")]
+        &app_menu,
         &edit_menu,
         #[cfg(target_os = "macos")]
         &view_menu,
@@ -200,7 +195,11 @@ fn build_menu_bar(window: &Window) -> anyhow::Result<Menu> {
     #[cfg(target_os = "linux")]
     menu_bar.init_for_gtk_window(window.gtk_window(), window.default_vbox())?;
     #[cfg(target_os = "macos")]
-    menu_bar.init_for_nsapp();
+    {
+        // The menu bar belongs to the application rather than to any window.
+        let _ = window;
+        menu_bar.init_for_nsapp();
+    }
 
     Ok(menu_bar)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,9 @@ use tao::platform::windows::WindowExtWindows;
 use tao::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoopBuilder, EventLoopProxy},
-    window::WindowBuilder,
+    window::{Window, WindowBuilder},
 };
-use wry::WebViewBuilder;
+use wry::{WebView, WebViewBuilder};
 
 mod auth;
 mod htime;
@@ -58,92 +58,14 @@ fn main() -> anyhow::Result<()> {
         .with_resizable(true)
         .build(&event_loop)?;
 
-    let menu_bar = Menu::new();
+    // Kept alive for as long as the window: dropping it would tear down the
+    // native menus it installed.
+    let _menu_bar = build_menu_bar(&window)?;
 
-    #[cfg(target_os = "macos")]
-    {
-        let app_m = Submenu::new("App", true);
-        menu_bar.append(&app_m)?;
-        app_m.append_items(&[
-            &PredefinedMenuItem::about(None, None),
-            &PredefinedMenuItem::separator(),
-            &PredefinedMenuItem::hide(None),
-            &PredefinedMenuItem::hide_others(None),
-            &PredefinedMenuItem::show_all(None),
-            &PredefinedMenuItem::separator(),
-            &PredefinedMenuItem::quit(None),
-        ])?;
-    }
-
-    let edit_menu = Submenu::new("&Edit", true);
-    edit_menu.append_items(&[
-        #[cfg(target_os = "macos")]
-        &PredefinedMenuItem::undo(None),
-        #[cfg(target_os = "macos")]
-        &PredefinedMenuItem::redo(None),
-        &PredefinedMenuItem::separator(),
-        &PredefinedMenuItem::cut(None),
-        &PredefinedMenuItem::copy(None),
-        &PredefinedMenuItem::paste(None),
-        &PredefinedMenuItem::select_all(None),
-    ])?;
-
-    let view_menu = Submenu::new("&View", true);
-    view_menu.append_items(&[&PredefinedMenuItem::fullscreen(None)])?;
-
-    let window_menu = Submenu::new("&Window", true);
-    window_menu.append_items(&[&PredefinedMenuItem::minimize(None)])?;
-
-    menu_bar.append_items(&[
-        &edit_menu,
-        #[cfg(target_os = "macos")]
-        &view_menu,
-        #[cfg(not(target_os = "linux"))]
-        &window_menu,
-    ])?;
-
-    #[cfg(target_os = "windows")]
-    unsafe {
-        menu_bar.init_for_hwnd(window.hwnd() as _)?;
-    }
-    #[cfg(target_os = "linux")]
-    menu_bar.init_for_gtk_window(window.gtk_window(), window.default_vbox())?;
-    #[cfg(target_os = "macos")]
-    menu_bar.init_for_nsapp();
-
-    let proxy = event_proxy.clone();
-
-    let builder = WebViewBuilder::new()
-        .with_navigation_handler(move |uri: String| {
-            let Ok(url) = Url::parse(&uri) else {
-                log::warn!("Ignoring malformed navigation URL: {uri}");
-                return false;
-            };
-
-            if !auth::is_redirect_url(&url) {
-                log::debug!("Navigating to {url} ...");
-                return true;
-            }
-
-            // Nothing on the system handles the callback scheme, so following
-            // it would at best fail and at worst hand the authorization code
-            // to whichever application claims it.
-            let _ = proxy.send_event(UserEvent::Redirect(url));
-            false
-        })
-        .with_clipboard(true)
-        .with_url(auth_url.as_str())
-        .with_devtools(true);
-
-    #[cfg(any(target_os = "windows", target_os = "macos",))]
-    let webview = builder.build(&window)?;
-
-    #[cfg(not(any(target_os = "windows", target_os = "macos",)))]
-    let webview = {
-        use wry::WebViewBuilderExtUnix;
-        let vbox = window.default_vbox().unwrap();
-        builder.build_gtk(vbox)?
-    };
+    let webview = build_webview(&window, auth_url.as_str(), true, {
+        let event_proxy = event_proxy.clone();
+        move |uri| handle_navigation(&event_proxy, uri)
+    })?;
 
     if args.clear_browsing_data {
         webview.clear_all_browsing_data()?;
@@ -211,6 +133,123 @@ fn init_logger(debug: bool) -> anyhow::Result<()> {
         .init()?;
 
     Ok(())
+}
+
+#[cfg_attr(
+    target_os = "macos",
+    expect(unused_variables, reason = "the menu bar belongs to the application")
+)]
+fn build_menu_bar(window: &Window) -> anyhow::Result<Menu> {
+    let menu_bar = Menu::new();
+
+    #[cfg(target_os = "macos")]
+    {
+        let app_menu = Submenu::new("App", true);
+        menu_bar.append(&app_menu)?;
+        app_menu.append_items(&[
+            &PredefinedMenuItem::about(None, None),
+            &PredefinedMenuItem::separator(),
+            &PredefinedMenuItem::hide(None),
+            &PredefinedMenuItem::hide_others(None),
+            &PredefinedMenuItem::show_all(None),
+            &PredefinedMenuItem::separator(),
+            &PredefinedMenuItem::quit(None),
+        ])?;
+    }
+
+    let edit_menu = Submenu::new("&Edit", true);
+    edit_menu.append_items(&[
+        #[cfg(target_os = "macos")]
+        &PredefinedMenuItem::undo(None),
+        #[cfg(target_os = "macos")]
+        &PredefinedMenuItem::redo(None),
+        &PredefinedMenuItem::separator(),
+        &PredefinedMenuItem::cut(None),
+        &PredefinedMenuItem::copy(None),
+        &PredefinedMenuItem::paste(None),
+        &PredefinedMenuItem::select_all(None),
+    ])?;
+
+    #[cfg(target_os = "macos")]
+    let view_menu = {
+        let view_menu = Submenu::new("&View", true);
+        view_menu.append_items(&[&PredefinedMenuItem::fullscreen(None)])?;
+        view_menu
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    let window_menu = {
+        let window_menu = Submenu::new("&Window", true);
+        window_menu.append_items(&[&PredefinedMenuItem::minimize(None)])?;
+        window_menu
+    };
+
+    menu_bar.append_items(&[
+        &edit_menu,
+        #[cfg(target_os = "macos")]
+        &view_menu,
+        #[cfg(not(target_os = "linux"))]
+        &window_menu,
+    ])?;
+
+    #[cfg(target_os = "windows")]
+    unsafe {
+        menu_bar.init_for_hwnd(window.hwnd() as _)?;
+    }
+    #[cfg(target_os = "linux")]
+    menu_bar.init_for_gtk_window(window.gtk_window(), window.default_vbox())?;
+    #[cfg(target_os = "macos")]
+    menu_bar.init_for_nsapp();
+
+    Ok(menu_bar)
+}
+
+fn build_webview(
+    window: &Window,
+    url: &str,
+    devtools: bool,
+    navigation_handler: impl Fn(String) -> bool + 'static,
+) -> anyhow::Result<WebView> {
+    let builder = WebViewBuilder::new()
+        .with_navigation_handler(navigation_handler)
+        .with_clipboard(true)
+        .with_url(url)
+        .with_devtools(devtools);
+
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
+    let webview = builder.build(window)?;
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    let webview = {
+        use wry::WebViewBuilderExtUnix;
+        let vbox = window
+            .default_vbox()
+            .ok_or_else(|| anyhow::anyhow!("Window has no GTK container"))?;
+        builder.build_gtk(vbox)?
+    };
+
+    Ok(webview)
+}
+
+/// Decides whether the webview may follow a navigation.
+///
+/// The callback URL uses a `tesla://` scheme that nothing on the system handles,
+/// so following it would at best fail and at worst hand the authorization code
+/// to whichever application happens to claim the scheme. Cancel it and take over
+/// the window instead.
+fn handle_navigation(event_proxy: &EventLoopProxy<UserEvent>, uri: String) -> bool {
+    let Ok(url) = Url::parse(&uri) else {
+        log::warn!("Ignoring malformed navigation URL");
+        return false;
+    };
+
+    if !auth::is_redirect_url(&url) {
+        log::debug!("Navigating to {url} ...");
+        return true;
+    }
+
+    let _ = event_proxy.send_event(UserEvent::Redirect(url));
+    false
 }
 
 /// Exchanges the authorization code on a background thread; the request blocks

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::sync::mpsc::{Sender, channel};
 use std::thread;
 
 use log::LevelFilter;
@@ -23,7 +22,7 @@ mod view;
 
 #[derive(Debug)]
 enum UserEvent {
-    /// The SSO flow reached the callback URL; the code exchange starts now.
+    /// The SSO flow reached the callback URL.
     Redirect(Url),
     Tokens(auth::Tokens),
     Failure(anyhow::Error),
@@ -48,10 +47,8 @@ fn main() -> anyhow::Result<()> {
     init_logger(args.debug)?;
 
     let event_loop = EventLoopBuilder::<UserEvent>::with_user_event().build();
-    let event_proxy = event_loop.create_proxy();
 
     let auth_client = auth::Client::new();
-    let auth_url = auth_client.authorize_url().clone();
 
     let window = WindowBuilder::new()
         .with_title("Tesla Auth")
@@ -62,9 +59,9 @@ fn main() -> anyhow::Result<()> {
     // native menus it installed.
     let _menu_bar = build_menu_bar(&window)?;
 
-    let webview = build_webview(&window, args.debug, {
-        let event_proxy = event_proxy.clone();
-        move |uri| handle_navigation(&event_proxy, uri)
+    let nav_proxy = event_loop.create_proxy();
+    let webview = build_webview(&window, args.debug, move |uri| {
+        handle_navigation(&nav_proxy, uri)
     })?;
 
     // Must happen before the first navigation, otherwise the stale session
@@ -73,10 +70,11 @@ fn main() -> anyhow::Result<()> {
         webview.clear_all_browsing_data()?;
     }
 
-    log::debug!("Opening {} ...", &auth_url[..Position::AfterPath]);
-    webview.load_url(auth_url.as_str())?;
+    webview.load_url(auth_client.authorize_url().as_str())?;
 
-    let tx = spawn_token_exchange(auth_client, event_proxy);
+    // Taken by the first callback: `authenticate` consumes the client.
+    let mut auth_client = Some(auth_client);
+    let event_proxy = event_loop.create_proxy();
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
@@ -91,8 +89,8 @@ fn main() -> anyhow::Result<()> {
             }
 
             Event::UserEvent(UserEvent::Redirect(url)) => {
-                if let Err(e) = tx.send(url) {
-                    log::error!("Token exchange is no longer running: {e}");
+                if let Some(client) = auth_client.take() {
+                    spawn_token_exchange(client, event_proxy.clone(), url);
                 }
                 view::progress()
             }
@@ -259,13 +257,9 @@ fn handle_navigation(event_proxy: &EventLoopProxy<UserEvent>, uri: String) -> bo
 fn spawn_token_exchange(
     client: auth::Client,
     event_proxy: EventLoopProxy<UserEvent>,
-) -> Sender<Url> {
-    let (tx, rx) = channel();
-
+    callback_url: Url,
+) {
     thread::spawn(move || {
-        // A single callback is all we get: `authenticate` consumes the client.
-        let Ok(callback_url) = rx.recv() else { return };
-
         let event = match client.authenticate(&callback_url) {
             Ok(auth::Outcome::Authorized(tokens)) => UserEvent::Tokens(tokens),
             Ok(auth::Outcome::Canceled) => UserEvent::LoginCanceled,
@@ -282,6 +276,4 @@ fn spawn_token_exchange(
             }
         }
     });
-
-    tx
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use tao::platform::unix::WindowExtUnix;
 use tao::platform::windows::WindowExtWindows;
 use tao::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoopBuilder, EventLoopProxy},
+    event_loop::{ControlFlow, EventLoopBuilder, EventLoopClosed, EventLoopProxy},
     window::{Window, WindowBuilder},
 };
 use wry::{WebView, WebViewBuilder};
@@ -272,7 +272,15 @@ fn spawn_token_exchange(
             Err(error) => UserEvent::Failure(error),
         };
 
-        let _ = event_proxy.send_event(event);
+        // The window may have been closed while the exchange was in flight. The
+        // tokens exist either way, so fall back to stdout rather than lose them.
+        if let Err(EventLoopClosed(event)) = event_proxy.send_event(event) {
+            match event {
+                UserEvent::Tokens(tokens) => println!("{tokens}"),
+                UserEvent::Failure(error) => log::error!("{error}"),
+                _ => (),
+            }
+        }
     });
 
     tx

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::mpsc::{Sender, channel};
 use std::thread;
 
@@ -65,7 +64,7 @@ fn main() -> anyhow::Result<()> {
     let event_proxy = event_loop.create_proxy();
 
     let auth_client = auth::Client::new();
-    let auth_url = auth_client.authorize_url();
+    let auth_url = auth_client.authorize_url().clone();
 
     let window = WindowBuilder::new()
         .with_title("Tesla Auth")
@@ -212,46 +211,27 @@ fn init_logger(debug: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Exchanges the authorization code on a background thread; the request blocks
+/// and would otherwise freeze the event loop.
 fn url_handler(client: auth::Client, event_proxy: EventLoopProxy<UserEvent>) -> Sender<Url> {
     let (tx, rx) = channel();
 
     thread::spawn(move || {
-        while let Ok(url) = rx.recv() {
-            if auth::is_redirect_url(&url) {
-                let event = handle_redirect(&url, client);
-                let _ = event_proxy.send_event(event);
-                return;
-            }
-        }
+        // A single callback is all we get: `authenticate` consumes the client.
+        let Some(url) = rx.into_iter().find(auth::is_redirect_url) else {
+            return;
+        };
+
+        let event = match client.authenticate(&url) {
+            Ok(auth::Outcome::Authorized(tokens)) => UserEvent::Tokens(tokens),
+            Ok(auth::Outcome::Canceled) => UserEvent::LoginCanceled,
+            Err(error) => UserEvent::Failure(error),
+        };
+
+        let _ = event_proxy.send_event(event);
     });
 
     tx
-}
-
-fn handle_redirect(url: &Url, client: auth::Client) -> UserEvent {
-    let query: HashMap<_, _> = url.query_pairs().collect();
-
-    if query.get("error").is_some_and(|v| v == "login_cancelled") {
-        return UserEvent::LoginCanceled;
-    }
-
-    let (Some(state), Some(code), Some(issuer)) =
-        (query.get("state"), query.get("code"), query.get("issuer"))
-    else {
-        return UserEvent::Failure(anyhow::anyhow!(
-            "Redirect URL missing required query parameters (state, code, or issuer)"
-        ));
-    };
-
-    let issuer_url = match Url::parse(issuer) {
-        Ok(url) => url,
-        Err(e) => return UserEvent::Failure(anyhow::anyhow!("Invalid issuer URL: {e}")),
-    };
-
-    match client.retrieve_tokens(code, state, &issuer_url) {
-        Ok(tokens) => UserEvent::Tokens(tokens),
-        Err(error) => UserEvent::Failure(error),
-    }
 }
 
 // Encode a string as a JSON string literal for safe JS interpolation.

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,18 +62,21 @@ fn main() -> anyhow::Result<()> {
     // native menus it installed.
     let _menu_bar = build_menu_bar(&window)?;
 
-    let webview = build_webview(&window, auth_url.as_str(), true, {
+    let webview = build_webview(&window, true, {
         let event_proxy = event_proxy.clone();
         move |uri| handle_navigation(&event_proxy, uri)
     })?;
 
+    // Must happen before the first navigation, otherwise the stale session
+    // cookies we are supposed to drop are sent along with it.
     if args.clear_browsing_data {
         webview.clear_all_browsing_data()?;
     }
 
-    let tx = spawn_token_exchange(auth_client, event_proxy);
-
     log::debug!("Opening {} ...", &auth_url[..Position::AfterPath]);
+    webview.load_url(auth_url.as_str())?;
+
+    let tx = spawn_token_exchange(auth_client, event_proxy);
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
@@ -206,14 +209,12 @@ fn build_menu_bar(window: &Window) -> anyhow::Result<Menu> {
 
 fn build_webview(
     window: &Window,
-    url: &str,
     devtools: bool,
     navigation_handler: impl Fn(String) -> bool + 'static,
 ) -> anyhow::Result<WebView> {
     let builder = WebViewBuilder::new()
         .with_navigation_handler(navigation_handler)
         .with_clipboard(true)
-        .with_url(url)
         .with_devtools(devtools);
 
     #[cfg(any(target_os = "windows", target_os = "macos"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ fn main() -> anyhow::Result<()> {
     // native menus it installed.
     let _menu_bar = build_menu_bar(&window)?;
 
-    let webview = build_webview(&window, true, {
+    let webview = build_webview(&window, args.debug, {
         let event_proxy = event_proxy.clone();
         move |uri| handle_navigation(&event_proxy, uri)
     })?;

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,0 +1,150 @@
+//! Standalone result pages.
+//!
+//! These replace the document in the webview once the SSO flow is done, so
+//! nothing here has to coexist with — or work around — Tesla's own markup.
+
+use crate::auth::Tokens;
+
+const STYLESHEET: &str = "\
+:root {
+  color-scheme: light dark;
+  --bg: #f3f4f6;
+  --card: #ffffff;
+  --fg: #111827;
+  --muted: #6b7280;
+  --border: #d1d5db;
+  --danger: #b91c1c;
+  --success: #15803d;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b0d10;
+    --card: #16191e;
+    --fg: #e5e7eb;
+    --muted: #9ca3af;
+    --border: #374151;
+    --danger: #f87171;
+    --success: #4ade80;
+  }
+}
+*, *::before, *::after { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  padding: 24px;
+  background: var(--bg);
+  color: var(--fg);
+  font: 16px/1.5 -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+main {
+  /* `margin: auto` rather than `align-items: center`, which clips the top of
+     the card once the content outgrows the viewport. */
+  margin: auto;
+  width: min(900px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 28px;
+  border-radius: 16px;
+  background: var(--card);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.12);
+}
+h1 { margin: 0; text-align: center; font-size: 30px; line-height: 1.2; }
+h2 { margin: 0; font-size: 15px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; color: var(--muted); }
+p { margin: 0; text-align: center; }
+p.muted { color: var(--muted); }
+p.danger { color: var(--danger); }
+p.success { color: var(--success); font-size: 14px; }
+textarea {
+  width: 100%;
+  height: 12em;
+  resize: vertical;
+  padding: 12px;
+  color: inherit;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  font: 13px/1.4 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+";
+
+/// Shown while the authorization code is being exchanged.
+pub fn progress() -> String {
+    page(
+        "<h1>Generating Tokens …</h1>\
+         <p class=\"muted\">Exchanging the authorization code with Tesla.</p>",
+    )
+}
+
+pub fn tokens(tokens: &Tokens) -> String {
+    page(&format!(
+        "<h1>Tesla API Tokens</h1>\
+         <h2>Access Token</h2>\
+         <textarea readonly onclick=\"this.select()\">{access}</textarea>\
+         <h2>Refresh Token</h2>\
+         <textarea readonly onclick=\"this.select()\">{refresh}</textarea>\
+         <p class=\"success\">Valid for {expires_in}</p>",
+        access = escape(tokens.access.secret()),
+        refresh = escape(tokens.refresh.secret()),
+        expires_in = escape(&tokens.expires_in.to_string()),
+    ))
+}
+
+pub fn error(error: &anyhow::Error) -> String {
+    page(&format!(
+        "<h1>An error occurred</h1>\
+         <p class=\"danger\">{}</p>\
+         <p class=\"muted\">Please restart tesla_auth and try again.</p>",
+        escape(&error.to_string()),
+    ))
+}
+
+fn page(body: &str) -> String {
+    format!(
+        "<!DOCTYPE html>\
+         <html lang=\"en\">\
+         <head>\
+         <meta charset=\"utf-8\">\
+         <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\
+         <title>Tesla Auth</title>\
+         <style>{STYLESHEET}</style>\
+         </head>\
+         <body><main>{body}</main></body>\
+         </html>"
+    )
+}
+
+/// Error messages can echo back attacker-controlled query parameters, so every
+/// interpolated value goes through here.
+fn escape(text: &str) -> String {
+    let mut escaped = String::with_capacity(text.len());
+
+    for c in text.chars() {
+        match c {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            _ => escaped.push(c),
+        }
+    }
+
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_html_metacharacters() {
+        assert_eq!(escape("a&b"), "a&amp;b");
+        assert_eq!(
+            escape("</textarea><script>alert('x')</script>"),
+            "&lt;/textarea&gt;&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;"
+        );
+        assert_eq!(escape("plain text"), "plain text");
+    }
+}


### PR DESCRIPTION
Some cleanup that piled up, plus a few things I noticed along the way.

The main change is how results are shown. Until now we injected a script that built a full-screen overlay on top of Tesla's own page, which meant patching their success message by class name and fighting their styles. The callback navigation is now cancelled and the document replaced with our own page instead, so none of that is necessary. There's also a progress page while the code is being exchanged.

Smaller fixes:

- `--debug` logged every navigation in full, including the callback URL with the authorization code and CSRF state in it
- `--clear-browsing-data` raced the initial navigation, since `with_url()` starts loading as soon as the webview is built
- No timeout on the token exchange, so an unresponsive endpoint just hung
- Tokens were dropped if the window was closed mid-exchange
- Devtools were always on; now behind `--debug`

And some tidying: callback parsing moved into `auth`, one OAuth client instead of two near-identical ones, and `main()` down from 139 lines to 78. The exchange thread is no longer started up front and parked on a channel waiting for the single callback URL it would ever receive — it is spawned when the callback arrives, which removes the channel entirely. `reqwest` was a direct dependency that nothing used (we go through oauth2's re-export, which is a different major version) and `serde_json` is no longer needed.

Tested the full flow on macOS. Windows and Linux only compile-checked — `load_html` maps to `NavigateToString` and webkit2gtk there, so worth a quick look before releasing. The menu bar is also built with `Submenu::with_items` now; the `cfg` predicates match muda's documented platform support (`fullscreen` macOS-only, `minimize` everywhere but Linux), but that path is untested off macOS too.
