### PR TITLE
Add a scheduled cargo-dist update check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 5
+    # Used *only* by release.yml, which dist generates — a bump here can't be
+    # applied by hand, since `dist plan` fails any PR that edits it. Don't add
+    # checkout or rust-cache: ci.yml shares those and must stay updatable.
+    ignore:
+      - dependency-name: "actions/upload-artifact"
+      - dependency-name: "actions/download-artifact"

--- a/.github/workflows/cargo-dist-update.yml
+++ b/.github/workflows/cargo-dist-update.yml
@@ -1,0 +1,56 @@
+name: Check for cargo-dist updates
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Open an issue if the pinned version is out of date
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          current=$(sed -n 's/^cargo-dist-version = "\(.*\)"/\1/p' dist-workspace.toml)
+          latest=$(gh api repos/axodotdev/cargo-dist/releases/latest --jq '.tag_name | ltrimstr("v")')
+
+          if [ -z "$current" ] || [ -z "$latest" ]; then
+            echo "Could not determine versions (pinned: '$current', latest: '$latest')" >&2
+            exit 1
+          fi
+
+          echo "pinned: $current, latest: $latest"
+
+          if [ "$current" = "$latest" ]; then
+            echo "Already up to date."
+            exit 0
+          fi
+
+          # Match the title prefix, not the exact version, so an issue left open
+          # for an older release doesn't get a duplicate when the next one lands.
+          open=$(gh issue list --state open --limit 100 --json title \
+            --jq 'any(.[]; .title | startswith("Upgrade cargo-dist to "))')
+          if [ "$open" = "true" ]; then
+            echo "An upgrade issue is already open."
+            exit 0
+          fi
+
+          gh issue create --title "Upgrade cargo-dist to $latest" --body-file - <<EOF
+          cargo-dist [$latest](https://github.com/axodotdev/cargo-dist/releases/tag/v$latest) is out; this repo pins $current.
+
+          See [Upgrading dist]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/blob/main/RELEASE.md#upgrading-dist) for the steps.
+
+          Opened automatically by \`.github/workflows/cargo-dist-update.yml\`.
+          EOF

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,3 +10,17 @@
 Pushing the tag triggers the [release workflow](.github/workflows/release.yml),
 which uses [cargo-dist](https://opensource.axo.dev/cargo-dist/) to build
 binaries for all targets and create a GitHub Release.
+
+## Upgrading dist
+
+`release.yml` is generated from `dist-workspace.toml`, so the version pin can't
+be bumped by editing either file — `dist plan` fails any PR that does. Let dist
+do it:
+
+```sh
+dist selfupdate --version X.Y.Z --yes  # updates the pin and regenerates release.yml
+dist plan                              # sanity check
+```
+
+A [scheduled workflow](.github/workflows/cargo-dist-update.yml) opens an issue
+when a new release is available.


### PR DESCRIPTION
Dependabot can't track the `cargo-dist-version` pin: it lives in `dist-workspace.toml`, and the other reference is a `curl` URL inside a `run:` step. Neither is a manifest Dependabot parses.

Adds a weekly workflow that compares the pin against the latest release and opens an issue when they differ. It skips if an upgrade issue is already open — matched on the title prefix rather than the exact version, so a stale issue for an older release doesn't collect a duplicate every time upstream ships.

The upgrade steps live in `RELEASE.md` rather than in the issue body, so they're findable without an open issue and reviewable in normal diffs. They now use `dist selfupdate`, which updates the pin and regenerates `release.yml` in one step, instead of the hand-edit recipe — and which matches how the project installs dist elsewhere.

Also tells Dependabot to leave `actions/upload-artifact` and `actions/download-artifact` alone. These appear only in the generated `release.yml`, and `dist plan` fails any PR that edits it by hand (see #103), so those bumps can't merge. `actions/checkout` and `swatinem/rust-cache` are deliberately *not* ignored — `ci.yml` shares them and must stay updatable.
