### PR TITLE
Fix Linux rendering and navigation issues, document the rest

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report a problem with tesla_auth
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please check the [troubleshooting section](https://github.com/adriankumpf/tesla_auth#troubleshooting) first — it may already cover your problem.
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `tesla_auth --version`.
+      placeholder: tesla_auth 0.14.0
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: Include the distribution and, on Linux, the desktop session and GPU driver.
+      placeholder: Ubuntu 24.04, GNOME on Wayland, NVIDIA proprietary
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: How did you install it?
+      options:
+        - Prebuilt binary from the releases page
+        - cargo install
+        - Distribution package (AUR, ...)
+        - Built from source
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: At which step of the login flow does it go wrong, what did you expect instead, and what happens now?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Output of `tesla_auth --debug`
+      description: Please redact anything that looks like a token, an authorization code or your email address.
+      render: shell
+    validations:
+      required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+- Disable WebKitGTK's DMA-BUF renderer by default on Linux, which fixes blank windows and immediate crashes on affected drivers (`WEBKIT_DISABLE_DMABUF_RENDERER=0` restores it)
+- Stop cancelling navigations whose URL cannot be parsed, which could take down an embedded captcha as the handler also sees subframe navigations
+- Add a `--version` flag
+- Document troubleshooting steps and the minimum distribution versions
+
 ## [0.14.0] - 2026-08-10
 
 - Show the tokens on a standalone result page, plus a progress page while the token exchange is in flight
@@ -120,6 +127,7 @@
 
 ## [0.1.0] - 2021-09-17
 
+[Unreleased]: https://github.com/adriankumpf/tesla_auth/compare/v0.14.0...HEAD
 [0.14.0]: https://github.com/adriankumpf/tesla_auth/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/adriankumpf/tesla_auth/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/adriankumpf/tesla_auth/compare/v0.11.0...v0.12.0

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ WebView2 provided by Microsoft Edge Chromium is used. So Windows 7, 8, 10 and 11
 
 ### Linux
 
-[WebKitGTK](https://webkitgtk.org/) is required for WebView and `libxdo` is used to make the predfined Copy, Cut, Paste and SelectAll menu items work. So please make sure the following packages are installed:
+[WebKitGTK](https://webkitgtk.org/) 4.1 is required for WebView and `libxdo` is used to make the predfined Copy, Cut, Paste and SelectAll menu items work. Ubuntu 22.04, Debian 12 and Fedora 36 are the earliest releases that ship WebKitGTK 4.1; on anything older neither the prebuilt binaries nor a local build will run.
+
+So please make sure the following packages are installed:
 
 #### Arch Linux / Manjaro:
 
@@ -66,6 +68,42 @@ sudo apt install libwebkit2gtk-4.1-dev libxdo-dev
 ```bash
 sudo dnf install gtk3-devel webkit2gtk4.1-devel xdotool
 ```
+
+## Troubleshooting
+
+Run `tesla_auth --debug` first: it prints the URLs the webview navigates to, which is usually enough to tell where a flow gets stuck.
+
+### Blank window, or a window that disappears immediately (Linux)
+
+WebKitGTK's accelerated rendering paths misbehave on a number of drivers, the NVIDIA proprietary one in particular. Typical symptoms are `Failed to create GBM buffer of size …` or `Error 71 (Protocol error) dispatching to Wayland display`.
+
+`tesla_auth` therefore disables the DMA-BUF renderer by default. If the window still does not come up, try:
+
+```bash
+WEBKIT_DISABLE_COMPOSITING_MODE=1 tesla_auth   # turn off compositing entirely
+GDK_BACKEND=x11 tesla_auth                     # run under XWayland
+WEBKIT_DISABLE_DMABUF_RENDERER=0 tesla_auth    # opt back into the default renderer
+```
+
+### The login form keeps returning to the sign-in page
+
+Stale cookies from a previous session are the usual cause. Start over with a clean profile:
+
+```bash
+tesla_auth --clear-browsing-data
+```
+
+### `Access Denied — You don't have permission to access … on this server`
+
+The request was rejected by Tesla's CDN before it ever reached the login page (the reference URL points at `errors.edgesuite.net`, i.e. Akamai). This is an IP reputation block rather than something `tesla_auth` can influence — disconnect from a VPN, or force a new public IP by power-cycling your router, and try again.
+
+### TeslaMate reports `Error: Tokens are invalid`
+
+The tokens are pasted into TeslaMate, which then talks to `auth.tesla.com` itself. If that request fails, TeslaMate reports the tokens as invalid even though they are fine — check its logs for the actual error, and retry once Tesla's SSO endpoints are healthy again.
+
+### macOS logs `_TIPropertyValueIsValid called with 11 on nil context!`
+
+Noise from the system input manager that any WebKit-based app produces. It has no effect on the login flow.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Supports MFA and Captcha through Tesla's native login flow.
 
 ```plain
 ❯ tesla_auth --help
-Usage: tesla_auth [-d] [-c]
+Usage: tesla_auth [-d] [-c] [-v]
 
 Tesla API tokens generator
 
@@ -25,6 +25,7 @@ Options:
   -d, --debug       print debug output
   -c, --clear-browsing-data
                     clear browsing data at startup
+  -v, --version     print the version and exit
   --help, help      display usage information
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,10 @@ struct Args {
     /// clear browsing data at startup
     #[argh(switch, short = 'c')]
     clear_browsing_data: bool,
+
+    /// print the version and exit
+    #[argh(switch, short = 'v')]
+    version: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -46,6 +50,11 @@ fn main() -> anyhow::Result<()> {
     disable_dmabuf_renderer();
 
     let args: Args = argh::from_env();
+
+    if args.version {
+        println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
 
     init_logger(args.debug)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,10 +257,15 @@ fn build_webview(
 /// so following it would at best fail and at worst hand the authorization code
 /// to whichever application happens to claim the scheme. Cancel it and take over
 /// the window instead.
+///
+/// Everything else is allowed through, a URI we cannot parse included: the
+/// handler also sees subframe navigations, so cancelling one risks taking an
+/// embedded captcha down with it, and a URI that fails to parse is by
+/// definition not the callback.
 fn handle_navigation(event_proxy: &EventLoopProxy<UserEvent>, uri: String) -> bool {
     let Ok(url) = Url::parse(&uri) else {
-        log::warn!("Ignoring malformed navigation URL");
-        return false;
+        log::debug!("Navigating to a URL we could not parse ...");
+        return true;
     };
 
     if !auth::is_redirect_url(&url) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,9 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+    disable_dmabuf_renderer();
+
     let args: Args = argh::from_env();
 
     init_logger(args.debug)?;
@@ -118,6 +121,25 @@ fn main() -> anyhow::Result<()> {
             log::error!("Failed to render page: {e}");
         }
     });
+}
+
+/// Opts out of WebKitGTK's DMA-BUF renderer.
+///
+/// It fails to allocate buffers on a number of drivers — the NVIDIA proprietary
+/// one above all — which shows up as `Failed to create GBM buffer`, a blank
+/// window, or a window that vanishes as soon as it opens. A login form has
+/// nothing to gain from GPU compositing, so take the safe path by default;
+/// `WEBKIT_DISABLE_DMABUF_RENDERER=0` puts it back.
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+fn disable_dmabuf_renderer() {
+    const VAR: &str = "WEBKIT_DISABLE_DMABUF_RENDERER";
+
+    if std::env::var_os(VAR).is_none() {
+        // SAFETY: called as the first statement of `main`, so the process is
+        // still single-threaded. It must also stay ahead of the event loop,
+        // which brings up GTK and with it threads that read the environment.
+        unsafe { std::env::set_var(VAR, "1") };
+    }
 }
 
 fn init_logger(debug: bool) -> anyhow::Result<()> {


### PR DESCRIPTION
Triage of the open issues, with fixes for the two that turned out to be real bugs plus the documentation that should keep the rest from being filed again.

### Fixes

- **Disable WebKitGTK's DMA-BUF renderer by default** (#72, and likely #101). It fails to allocate buffers on a number of drivers, the NVIDIA proprietary one above all, which leaves a blank window or one that disappears the moment it opens. A login form gains nothing from GPU compositing, so it is off unless `WEBKIT_DISABLE_DMABUF_RENDERER` is already set — `WEBKIT_DISABLE_DMABUF_RENDERER=0` opts back in. Confirmed against WebKit's `AcceleratedBackingStore.cpp`, which tests `disableDMABuf && g_strcmp0(disableDMABuf, "0")`.
- **Allow navigations to URLs that cannot be parsed** (possibly #73). `handle_navigation` cancelled anything `Url::parse` rejected, and wry's GTK backend routes *every* `NavigationAction` policy decision through that handler, subframes included — so a cancel there can blank out an embedded captcha. A URI we fail to parse is never the `tesla://` callback, which makes letting it through both safe and less disruptive.

### Additions

- `--version`, since bug reports rarely say which version they are about.
- A bug report issue template requiring version, OS, install method and `--debug` output.
- A troubleshooting section covering the reports that are not bugs here: blank windows on Linux (#72, #101), sign-in loops (#80), Akamai's `Access Denied` (#94), TeslaMate rejecting the tokens (#75), macOS input-manager log noise (#77), and which distribution releases actually ship WebKitGTK 4.1 (#74).

### Notes

The DMA-BUF change affects every Linux user, not only the ones on broken drivers. Both fixes are reasoned from the WebKit and wry sources plus reporter confirmations rather than tested on affected hardware — neither can be reproduced on macOS.
